### PR TITLE
Adding support for automatic webhook creation on settings save.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     }
   ],
   "require": {
-    "nodeless-io/nodeless-php": "dev-main"
+    "nodeless-io/nodeless-php": "dev-webhook"
   }
 }

--- a/src/Helper/ApiHelper.php
+++ b/src/Helper/ApiHelper.php
@@ -8,97 +8,77 @@ use NodelessIO\Client\StoreClient;
 use NodelessIO\Client\StoreInvoiceClient;
 
 class ApiHelper {
-	public bool $configured = false;
-	public string $url;
-	public string $apiKey;
-	public string $storeId;
-	public string $webhookSecret;
+    public bool $configured = false;
+    public string $url;
+    public string $apiKey;
+    public string $storeId;
+    public string $webhookSecret;
 
-	public function __construct() {
-		if ( $config = self::getConfig() ) {
-			$this->url = $config['url'];
-			$this->apiKey = $config['api_key'];
-			$this->storeId = $config['store_id'];
-			$this->webhookSecret = $config['webhook_secret'];
-			$this->configured = true;
-		}
-	}
+    public function __construct() {
+        if ( $config = self::getConfig() ) {
+            $this->url = $config['url'];
+            $this->apiKey = $config['api_key'];
+            $this->storeId = $config['store_id'];
+            $this->configured = true;
+        }
+    }
 
-	public static function getConfig(): array {
-		$url = get_option( 'nodeless_url' );
-		$key = get_option( 'nodeless_api_key' );
-		if ( $url && $key ) {
-			return [
-				'url' => rtrim( $url, '/' ),
-				'api_key' => $key,
-				'store_id' => get_option( 'nodeless_store_id', null ),
-				'webhook_secret' => get_option( 'nodeless_webhook_secret', null ),
-			];
-		} else {
-			return [];
-		}
-	}
+    public static function getConfig(): array {
+        $url = get_option( 'nodeless_url' );
+        $key = get_option( 'nodeless_api_key' );
+        if ( $url && $key ) {
+            return [
+                'url' => rtrim( $url, '/' ),
+                'api_key' => $key,
+                'store_id' => get_option( 'nodeless_store_id', null ),
+            ];
+        } else {
+            return [];
+        }
+    }
 
-	public static function checkApiConnection( string $host, string $apiKey, string $storeId ): bool {
-		$client = new StoreClient( $host, $apiKey );
-		if ( ! empty( $client->getStore( $storeId ) ) ) {
-			return true;
-		}
+    public static function checkApiConnection( string $host, string $apiKey, string $storeId ): bool {
+        $client = new StoreClient( $host, $apiKey );
+        if ( ! empty( $client->getStore( $storeId ) ) ) {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/**
-	 * Check webhook signature to be a valid request.
-	 */
-	public function validWebhookRequest( string $signature, string $requestData ): bool {
-		Logger::debug( __FUNCTION__ . ' Signature: ' . $signature );
-		Logger::debug( __FUNCTION__ . ' Configured: ' . $this->configured );
-		if ( $this->configured ) {
-			$expectedHeader = hash_hmac( 'sha256', $requestData, $this->webhookSecret );
-			Logger::debug( __FUNCTION__ . ' Expected header: ' . $expectedHeader );
+    /**
+     * Checks if the provided API config already exists in options table.
+     */
+    public static function apiCredentialsExist( string $apiUrl, string $apiKey, string $storeId ): bool {
+        if ( $config = self::getConfig() ) {
+            if (
+                $config['url'] === $apiUrl &&
+                $config['api_key'] === $apiKey &&
+                $config['store_id'] === $storeId
+            ) {
+                return true;
+            }
+        }
 
-			if ( $expectedHeader === $signature ) {
-				return true;
-			}
-		}
+        return false;
+    }
 
-		return false;
-	}
+    /**
+     * Checks if a given invoice id has status of fully paid (settled) or paid late.
+     */
+    public static function invoiceIsFullyPaid( string $invoiceId ): bool {
+        if ( $config = self::getConfig() ) {
+            $client = new StoreInvoiceClient( $config['url'], $config['api_key'] );
+            try {
+                $invoice = $client->getInvoice( $config['store_id'], $invoiceId );
 
-	/**
-	 * Checks if the provided API config already exists in options table.
-	 */
-	public static function apiCredentialsExist( string $apiUrl, string $apiKey, string $storeId ): bool {
-		if ( $config = self::getConfig() ) {
-			if (
-				$config['url'] === $apiUrl &&
-				$config['api_key'] === $apiKey &&
-				$config['store_id'] === $storeId
-			) {
-				return true;
-			}
-		}
+                return $invoice->isPaid() || $invoice->isOverpaid();
+            } catch ( \Throwable $e ) {
+                Logger::debug( 'Exception while checking if invoice settled ' . $invoiceId . ': ' . $e->getMessage() );
+            }
+        }
 
-		return false;
-	}
-
-	/**
-	 * Checks if a given invoice id has status of fully paid (settled) or paid late.
-	 */
-	public static function invoiceIsFullyPaid( string $invoiceId ): bool {
-		if ( $config = self::getConfig() ) {
-			$client = new StoreInvoiceClient( $config['url'], $config['api_key'] );
-			try {
-				$invoice = $client->getInvoice( $config['store_id'], $invoiceId );
-
-				return $invoice->isPaid() || $invoice->isOverpaid();
-			} catch ( \Throwable $e ) {
-				Logger::debug( 'Exception while checking if invoice settled ' . $invoiceId . ': ' . $e->getMessage() );
-			}
-		}
-
-		return false;
-	}
+        return false;
+    }
 
 }

--- a/src/Helper/ApiWebhook.php
+++ b/src/Helper/ApiWebhook.php
@@ -15,7 +15,7 @@ class ApiWebhook {
         'cancelled',
         'underpaid',
         'overpaid',
-        // 'in_flight'
+        'in_flight'
     ];
 
 	/**

--- a/src/Helper/ApiWebhook.php
+++ b/src/Helper/ApiWebhook.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NodelessIO\WC\Helper;
+
+use NodelessIO\Response\StoreWebhookResponse;
+use NodelessIO\Client\StoreWebhookClient;
+
+class ApiWebhook {
+    public const WEBHOOK_STATUSES = [
+        'pending_confirmation',
+        'paid',
+        'expired',
+        'cancelled',
+        'underpaid',
+        'overpaid',
+        // 'in_flight'
+    ];
+
+	/**
+	 * Get locally stored webhook data and check if it exists on the store.
+	 */
+	public static function webhookExists(string $apiUrl, string $apiKey, string $storeId): bool {
+		if ( $storedWebhook = get_option( 'nodeless_webhook' ) ) {
+			try {
+				$client = new StoreWebhookClient( $apiUrl, $apiKey );
+				$existingWebhook = $client->getWebhook( $storeId, $storedWebhook['id'] );
+				// Check for the url here as it could have been changed on BTCPay Server making the webhook not work for WooCommerce anymore.
+				if (
+					$existingWebhook->getId() === $storedWebhook['id'] &&
+					strpos( $existingWebhook->getData()['url'], $storedWebhook['url'] ) !== false
+				) {
+					return true;
+				}
+			} catch (\Throwable $e) {
+				Logger::debug('Error fetching existing Webhook from nodeless.io. Message: ' . $e->getMessage());
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Register a webhook on BTCPay Server and store it locally.
+	 */
+	public static function registerWebhook(string $apiUrl, $apiKey, $storeId): ?StoreWebhookResponse {
+		try {
+			$client = new StoreWebhookClient( $apiUrl, $apiKey );
+            $secret = wp_generate_password(20);
+            $url = WC()->api_request_url( 'nodeless' );
+
+            $webhook = $client->createWebhook(
+                $storeId,
+                'store',
+                $url,
+                self::WEBHOOK_STATUSES,
+                $secret,
+                'active'
+            );
+
+			// Store in option table.
+			update_option(
+				'nodeless_webhook',
+				[
+					'id' => $webhook->getId(),
+					'secret' => $secret,
+					'url' => $url
+				]
+			);
+
+			return $webhook;
+		} catch (\Throwable $e) {
+			Logger::debug('Error creating a new webhook nodeless.io: ' . $e->getMessage());
+		}
+
+		return null;
+	}
+
+	/**
+	 * Load existing webhook data from BTCPay Server, defaults to locally stored webhook.
+	 */
+	public static function getWebhook(?string $webhookId): ?StoreWebhookResponse {
+		$existingWebhook = get_option('nodeless_webhook');
+		$config = ApiHelper::getConfig();
+
+		try {
+			$client = new StoreWebhookClient( $config['url'], $config['api_key'] );
+			$webhook = $client->getWebhook(
+				$config['store_id'],
+				$webhookId ?? $existingWebhook['id'],
+				);
+
+			return $webhook;
+		} catch (\Throwable $e) {
+			Logger::debug('Error fetching existing Webhook from nodeless.io: ' . $e->getMessage());
+		}
+
+		return null;
+	}
+
+    /**
+     * Check webhook signature to be a valid request.
+     */
+    public static function validWebhookRequest( string $signature, string $requestData ): bool {
+        $storedWebhook = get_option( 'nodeless_webhook' );
+        Logger::debug( __FUNCTION__ . ' Signature: ' . $signature );
+        Logger::debug( __FUNCTION__ . ' Configured: ' . $storedWebhook['secret'] );
+        if ( ApiHelper::getConfig() ) {
+            $expectedHeader = hash_hmac( 'sha256', $requestData, $storedWebhook['secret'] );
+            Logger::debug( __FUNCTION__ . ' Expected header: ' . $expectedHeader );
+
+            if ( $expectedHeader === $signature ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}


### PR DESCRIPTION
Delete an existing old webhook if needed. After entering the api details in settings form you will see a notification that the webhook was created (but only on first time saving). 

[nodelessio-for-woocommerce.0.1.0.zip](https://github.com/nodeless-io/nodeless-woocommerce/files/10509155/nodelessio-for-woocommerce.0.1.0.zip)
