### PR TITLE
New release to check release flow and align plugin version with tags.

### DIFF
--- a/nodeless-for-woocommerce.php
+++ b/nodeless-for-woocommerce.php
@@ -7,7 +7,7 @@
  * Author URI:      https://nodeless.io
  * Text Domain:     nodeless-for-woocommerce
  * Domain Path:     /languages
- * Version:         0.2.0
+ * Version:         1.0.1
  * Requires PHP:    8.0
  * Tested up to:    6.1
  * Requires at least: 5.6
@@ -23,7 +23,7 @@ use NodelessIO\WC\Helper\Logger;
 
 defined( 'ABSPATH' ) || exit();
 
-define( 'NODELESS_VERSION', '0.2.0' );
+define( 'NODELESS_VERSION', '1.0.1' );
 define( 'NODELESS_VERSION_KEY', 'nodeless_version' );
 define( 'NODELESS_PLUGIN_FILE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'NODELESS_PLUGIN_URL', plugin_dir_url(__FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ A: Yes you can go to https://testnet.nodeless.io and use it with testnet bitcoin
 
 == Changelog ==
 
-= 1.0.1 :: 2023-03-16 =
+= 1.0.1 :: 2023-03-19 =
 * Testing deployment flow with another release.
 
 = 1.0.0 :: 2023-03-16 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Bitcoin, Lightning Network, WooCommerce, payment gateway, accept bitcoin, 
 Requires at least: 5.9
 Tested up to: 6.1
 Requires PHP: 8.0
-Stable tag: 0.2.0
+Stable tag: 1.0.1
 License: MIT
 License URI: https://github.com/nodeless-io/nodeless-woocommerce/blob/master/license.txt
 
@@ -42,5 +42,8 @@ A: Yes you can go to https://testnet.nodeless.io and use it with testnet bitcoin
 
 == Changelog ==
 
-= 0.1.0 :: 2023-03-10 =
+= 1.0.1 :: 2023-03-16 =
+* Testing deployment flow with another release.
+
+= 1.0.0 :: 2023-03-16 =
 * First release.

--- a/src/Admin/GlobalSettings.php
+++ b/src/Admin/GlobalSettings.php
@@ -54,7 +54,7 @@ class GlobalSettings extends \WC_Settings_Page {
 					'nodeless-for-woocommerce'
 				),
 				'type' => 'title',
-				'desc' => sprintf( _x( 'This plugin version is %s and your PHP version is %s. Check out our <a href="https://docs.nodeless.io/WooCommerce/" target="_blank">installation instructions</a>. If you need assistance, please come on our <a href="https://chat.nodeless.io" target="_blank">chat</a>. Thank you for using Nodeless.io!', 'global_settings', 'nodeless-for-woocommerce' ), NODELESS_VERSION, PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION ),
+				'desc' => sprintf( _x( 'This plugin version is %s and your PHP version is %s. Check out our <a href="https://wordpress.org/plugins/nodeless-for-woocommerce/#installation" target="_blank">installation instructions</a>. If you need assistance, please visit our <a href="https://support.nodeless.io" target="_blank">helpdesk</a>. Thank you for using Nodeless!', 'global_settings', 'nodeless-for-woocommerce' ), NODELESS_VERSION, PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION ),
 				'id' => 'nodeless'
 			],
 			'mode' => [


### PR DESCRIPTION
**How to do a new release on WP.org:**

e.g. version 1.0.1, you need to change 3 places:

- Change the Version (at the top in the DocBlock which is plugin metadata) in the plugin entry file `nodeless-for-woocommerce.php`
- Change the constant `NODELESS_VERSION` in that same file.
- Change the stable tag to match the version, 1.0.1 in the `readme.txt` 

**To deploy it to wp.org:**

- Create a new release (or push a tag) with that same version prefixed by `v` eg. `v1.0.1` 
- Check that the workflow ran without any error
- Done

**Additonal note:**
All the visible stuff on the plugin page on wp.org is rendered from the `readme.txt`
